### PR TITLE
Remove the use_cache feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,19 +112,6 @@ explainer = WoodelfExplainer(xgb_model, X_train)
 background_iv_df = explainer.shap_interaction_values(X_test, as_df=True, exclude_zero_contribution_features=False)
 ```
 
-#### Built-in Cache
-
-The cache stores the preprocessed background data, eliminating the need to recompute it across repeated uses of the same explainer instance. By default, caching is disabled.
-
-**Note:** Caching may be memory-intensive for deep trees (e.g., `max_depth ≥ 8`).
-```python
-explainer = WoodelfExplainer(xgb_model, X_train, use_cache=True)
-shap_sample_1 = explainer.shap_values(X_test.sample(100))
-# No need to preprocess the background data from here on, the cache will be used instead.
-shap_sample_2 = explainer.shap_values(X_test.sample(100)) 
-shap_sample_3 = explainer.shap_values(X_test.sample(100))
-...
-```
 
 ## Partial Dependence Plots (PDP)
 

--- a/tests/test_explainer.py
+++ b/tests/test_explainer.py
@@ -1,7 +1,6 @@
 import time
 
 import numpy as np
-import pandas as pd
 import shap
 import xgboost as xgb
 
@@ -130,47 +129,6 @@ def test_excluding_only_zero_contributions(trainset, testset, xgb_model):
             # assert all zeros
             assert woodelf_df[f].abs().max() == 0
 
-
-def test_explainer_cache(trainset, testset, xgb_model):
-    woodelf_head_5_df_1 = WoodelfExplainer(xgb_model, trainset.head(5), feature_perturbation='interventional').shap_values(
-        testset.head(5), as_df=True, exclude_zero_contribution_features=False
-    )
-    woodelf_tail_5_df_1 = WoodelfExplainer(xgb_model, trainset.tail(5), feature_perturbation='interventional').shap_values(
-        testset.head(5), as_df=True, exclude_zero_contribution_features=False
-    )
-
-    # When there is no cache one can modify the background data on the explainer, run shap and it will use
-    # the new background data (this is for testing, please never actually do it in an important code)
-    woodelf_explainer = WoodelfExplainer(
-        xgb_model, trainset.head(5), feature_perturbation='interventional', use_cache=False
-    )
-    woodelf_head_5_df_2 = woodelf_explainer.shap_values(
-        testset.head(5), as_df=True, exclude_zero_contribution_features=False
-    )
-    pd.testing.assert_frame_equal(woodelf_head_5_df_1, woodelf_head_5_df_2)
-
-    woodelf_explainer.background_data = trainset.tail(5)
-    woodelf_tail_5_df_2 = woodelf_explainer.shap_values(
-        testset.head(5), as_df=True, exclude_zero_contribution_features=False
-    )
-    pd.testing.assert_frame_equal(woodelf_tail_5_df_1, woodelf_tail_5_df_2)
-
-    # When the cache is enabled setting the background data will have no effect as the object
-    # already extracted the needed information from the background data and does not need to reuse it
-    woodelf_explainer = WoodelfExplainer(
-        xgb_model, trainset.head(5), feature_perturbation='interventional', use_cache=True
-    )
-    woodelf_head_5_df_3 = woodelf_explainer.shap_values(
-        testset.head(5), as_df=True, exclude_zero_contribution_features=False
-    )
-    assert woodelf_explainer.cache is not None and woodelf_explainer.cache_filled
-    pd.testing.assert_frame_equal(woodelf_head_5_df_1, woodelf_head_5_df_3)
-
-    woodelf_explainer.background_data = trainset.tail(5)
-    woodelf_head_5_df_4 = woodelf_explainer.shap_values(
-        testset.head(5), as_df=True, exclude_zero_contribution_features=False
-    ) # This is the test! return the background shap of head(5) although we just override the background data to tail(5)
-    pd.testing.assert_frame_equal(woodelf_head_5_df_1, woodelf_head_5_df_4)
 
 
 def test_expected_value_property(trainset, testset, xgb_model):

--- a/woodelf/explainer.py
+++ b/woodelf/explainer.py
@@ -20,10 +20,9 @@ class WoodelfExplainer:
             self, model, data: pd.DataFrame = None,
             model_output : str="raw", feature_perturbation: str="auto",
             # Additional options exists only in Woodelf:
-            use_cache: bool = False, GPU: bool = False
+            GPU: bool = False
     ):
         self.raw_model = model
-        self.use_cache = use_cache and data is not None
         self.background_data = data
 
         self.verify_init_input(model_output, feature_perturbation)
@@ -42,8 +41,6 @@ class WoodelfExplainer:
             else:
                 self.model: DecisionTreesEnsemble = load_decision_tree_ensemble_model(model, list(data.columns))
             self.model_was_loaded = True
-            self.cache = [{} for i in range(len(self.model.trees))] if self.use_cache else None
-            self.cache_filled = False
         else:
             self.model_was_loaded = False
 
@@ -131,26 +128,15 @@ class WoodelfExplainer:
         if not self.model_was_loaded:
             self.model = load_decision_tree_ensemble_model(self.raw_model, list(consumer_data.columns))
             self.model_was_loaded = True
-            self.cache = [{} for i in range(len(self.model.trees))] if self.use_cache else None
-            self.cache_filled = False
 
         model = self.model if tree_limit is None else DecisionTreesEnsemble(self.model.trees[:tree_limit])
-        cache_kwargs = {}
-        if self.cache is not None:
-            if self.cache_filled:
-                # use the cache
-                cache_kwargs["cache_to_use"] = self.cache
-            else:
-                # fill the cache
-                cache_kwargs["cache_to_fill"] = self.cache
-                self.cache_filled = True # will fill the cache now
 
-        if self.cache is None and path_to_matrices_calculator is None and not self.GPU:
+        if path_to_matrices_calculator is None and not self.GPU:
             woodelf_values = hybrid_woodelf(model, consumer_data, self.background_data, metric, GPU=self.GPU, model_was_loaded=True)
         else:
             woodelf_values = woodelf_for_high_depth(
                 model, consumer_data, self.background_data, metric, GPU=self.GPU,
-                path_to_matrices_calculator=path_to_matrices_calculator, model_was_loaded=True, **cache_kwargs
+                path_to_matrices_calculator=path_to_matrices_calculator, model_was_loaded=True,
             )
 
         return self._output_formatting(

--- a/woodelf/high_depth_woodelf.py
+++ b/woodelf/high_depth_woodelf.py
@@ -8,7 +8,7 @@ from woodelf.core.cube_metric import CubeMetric
 from woodelf.core.decision_patterns import decision_patterns_generator, ignore_right_neighbor
 from woodelf.core.trees.decision_trees_ensemble import DecisionTreeNode
 from woodelf.core.trees.parse_models import load_decision_tree_ensemble_model
-from woodelf.core.path_to_s_vectors.base_p2s import PathToSVectors, compute_f_from_patterns
+from woodelf.core.path_to_s_vectors.base_p2s import PathToSVectors
 from woodelf.core.path_to_s_vectors.woodelf_p2s import HighDepthWoodelfPathToSVectors
 from woodelf.core.utils import get_unique_features_in_path, get_covers_vector
 from woodelf.simple_woodelf import get_cupy_data, fill_mirror_pairs
@@ -25,7 +25,7 @@ except ModuleNotFoundError as e:
 def woodelf_for_high_depth_single_tree(
         tree: DecisionTreeNode, consumer_data: pd.DataFrame, background_data: pd.DataFrame,
         values: Dict[Any, float], path_to_matrices_calculator: PathToSVectors, GPU: bool = False,
-        use_neighbor_leaf_trick: bool = True, global_importance: bool = False, cache_to_use: Dict = None, cache_to_fill: Dict = None
+        use_neighbor_leaf_trick: bool = True, global_importance: bool = False
 ):
     """
     Run the woodelf algorithm that is optimized for a high depth trees on a single tree
@@ -47,17 +47,9 @@ def woodelf_for_high_depth_single_tree(
             leaf_b, background_patterns = next(background_patterns_generator)
             assert leaf_b.index == leaf.index
 
-            if cache_to_use is not None and leaf.index in cache_to_use and isinstance(path_to_matrices_calculator, HighDepthWoodelfPathToSVectors):
-                s_matrix = path_to_matrices_calculator.compose_with_neighbor_trick(
-                    unique_features_in_path, cache_to_use[leaf.index], leaf.value, w_neighbor
-                )
-            else:
-                s_matrix = path_to_matrices_calculator.get_background_s_matrix(
-                    unique_features_in_path, consumer_patterns, background_patterns, leaf.value, w_neighbor
-                )
-                if cache_to_fill is not None:
-                    depth = len(unique_features_in_path)
-                    cache_to_fill[leaf.index] = compute_f_from_patterns(background_patterns, depth, GPU)
+            s_matrix = path_to_matrices_calculator.get_background_s_matrix(
+                unique_features_in_path, consumer_patterns, background_patterns, leaf.value, w_neighbor
+            )
         else:
             covers = np.array(get_covers_vector(path + [leaf], unique_features_in_path))
             s_matrix = path_to_matrices_calculator.get_path_dependent_s_matrix(
@@ -79,7 +71,7 @@ def woodelf_for_high_depth(
         model, consumer_data: pd.DataFrame, background_data: Optional[pd.DataFrame], metric: CubeMetric,
         GPU: bool=False, use_neighbor_leaf_trick: bool=True,
         path_to_matrices_calculator: PathToSVectors = None,
-        global_importance: bool = False, cache_to_use: List[Dict] = None, cache_to_fill: List[Dict] = None, model_was_loaded: bool = False
+        global_importance: bool = False, model_was_loaded: bool = False
 ):
     """
     WOODELF designed for higher depths decision trees.
@@ -101,9 +93,6 @@ def woodelf_for_high_depth(
     on large/medium size datasets)
     @param global_importance: If true return the average value across all consumer data rows. Used to
     save RAM.
-    @param cache_to_use: Cache to use and save some time (on Background approach only)
-    @param cache_to_fill: Fill the given cache so next time will be faster (on Background approach only)
-
     @return The computed values as a dictionary that maps between features/features pairs to np.arrays with
     the values.
     """
@@ -134,8 +123,6 @@ def woodelf_for_high_depth(
         woodelf_for_high_depth_single_tree(
             tree, consumer_data, background_data, values, path_to_matrices_calculator, GPU,
             use_neighbor_leaf_trick, global_importance,
-            cache_to_use[tree_index] if cache_to_use is not None else None,
-            cache_to_fill[tree_index] if cache_to_fill is not None else None
         )
 
     if not metric.INTERACTION_VALUES_ORDER_MATTERS and metric.INTERACTION_VALUE:


### PR DESCRIPTION
Remove the use_cache feature.
Its hard to maintain, can explode the RAM when use on too large / too deep trees and is not supported by the newer O(mn) improved approach and vectorized linear tree shap approach.